### PR TITLE
Fix video frame display incorrectly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Byte-compiled
 __pycache__/
+
+# Cache files created by program but not properly deleted
+cache-*.jpg

--- a/Code/Client.py
+++ b/Code/Client.py
@@ -119,7 +119,9 @@ class Client:
 
 	def updateMovie(self, imageFile):
 		"""Update the image file as video frame in the GUI."""
-		self.label.config(image = ImageTk.PhotoImage(Image.open(imageFile)))
+		image = ImageTk.PhotoImage(Image.open(imageFile))
+		self.label.config(image = image, height=400)
+		self.label.image = image
 
 	def connectToServer(self):
 		"""Connect to the Server. Start a new RTSP/TCP session."""


### PR DESCRIPTION
Update  `updateMovie()` function in `Client.py`
- Set height value when update label image

    It seem like, by default when not configure Tkinter label text or image attribute, Tkinter label will displays as text and the height unit is line. However when Tkinter label image being configured, it displays as image and height unit is image pixel.

- Set Tkinter label image property

    I don't know why, it make Windows OS run properly